### PR TITLE
When ver doesn't change, don't commit and push.

### DIFF
--- a/.github/fix-docs-version.sh
+++ b/.github/fix-docs-version.sh
@@ -17,5 +17,5 @@ update_file_versions ${VERSION} README.md
 git add README.md
 git config --local user.email "$(git log --format='%ae' HEAD^!)"
 git config --local user.name "$(git log --format='%an' HEAD^!)"
-git commit -m "[skip ci] Updated README version"
-git push origin HEAD:master
+git add -A
+git diff-index --quiet HEAD || git commit -m "[skip ci] Updated README version" & git push origin HEAD:master


### PR DESCRIPTION
When the documentation file, the version does not change, do not execute commit and push.

Sometimes the documentation already reflects the version, and the command fails because when trying to make the modification it has nothing to commit.